### PR TITLE
feat: add merchant surprise management pages and types

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -181,6 +181,21 @@ const ServiceManagePage = React.lazy(() =>
 const ServiceCheckInPage = React.lazy(() =>
   import('./pages/merchant/ServiceCheckInPage').then((m) => ({ default: m.ServiceCheckInPage })),
 );
+const MerchantMySurprisesPage = React.lazy(() =>
+  import('./pages/merchant/MerchantMySurprisesPage').then((m) => ({ default: m.MerchantMySurprisesPage })),
+);
+const SurpriseCreatePage = React.lazy(() =>
+  import('./pages/merchant/SurpriseCreatePage').then((m) => ({ default: m.SurpriseCreatePage })),
+);
+const SurpriseAnalyticsPage = React.lazy(() =>
+  import('./pages/merchant/SurpriseAnalyticsPage').then((m) => ({ default: m.SurpriseAnalyticsPage })),
+);
+const SurprisesPage = React.lazy(() =>
+  import('./pages/SurprisesPage').then((m) => ({ default: m.SurprisesPage })),
+);
+const MyRevealHistoryPage = React.lazy(() =>
+  import('./pages/MyRevealHistoryPage').then((m) => ({ default: m.MyRevealHistoryPage })),
+);
 import { LoadingOverlay } from '@/components/ui/LoadingOverlay';
 import { ScrollToTop } from '@/components/common/ScrollToTop';
 import { PaymentSuccessPage } from './pages/PaymentSuccessPage';
@@ -876,6 +891,68 @@ function App() {
                     }
                   />
                 </Route>
+
+                {/* Consumer Surprises */}
+                <Route element={<DefaultLayout />}>
+                  <Route
+                    path={PATHS.SURPRISES}
+                    element={
+                      <ProtectedRoute>
+                        <Suspense fallback={<LoadingOverlay />}>
+                          <SurprisesPage />
+                        </Suspense>
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path={PATHS.MY_REVEAL_HISTORY}
+                    element={
+                      <ProtectedRoute>
+                        <Suspense fallback={<LoadingOverlay />}>
+                          <MyRevealHistoryPage />
+                        </Suspense>
+                      </ProtectedRoute>
+                    }
+                  />
+                </Route>
+
+                {/* Merchant Surprises */}
+                <Route
+                  path={PATHS.MERCHANT_SURPRISES}
+                  element={
+                    <ProtectedRoute>
+                      <MerchantLayout>
+                        <Suspense fallback={<LoadingOverlay />}>
+                          <MerchantMySurprisesPage />
+                        </Suspense>
+                      </MerchantLayout>
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={PATHS.MERCHANT_SURPRISES_CREATE}
+                  element={
+                    <ProtectedRoute>
+                      <MerchantLayout>
+                        <Suspense fallback={<LoadingOverlay />}>
+                          <SurpriseCreatePage />
+                        </Suspense>
+                      </MerchantLayout>
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path={PATHS.MERCHANT_SURPRISES_ANALYTICS}
+                  element={
+                    <ProtectedRoute>
+                      <MerchantLayout>
+                        <Suspense fallback={<LoadingOverlay />}>
+                          <SurpriseAnalyticsPage />
+                        </Suspense>
+                      </MerchantLayout>
+                    </ProtectedRoute>
+                  }
+                />
 
                 {/* Consumer Nudge History */}
                 <Route element={<DefaultLayout />}>

--- a/web/src/components/layout/MerchantHeader.tsx
+++ b/web/src/components/layout/MerchantHeader.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS = [
   { to: PATHS.MERCHANT_DEALS, label: 'My Deals' },
   { to: PATHS.MERCHANT_EVENTS, label: 'My Events' },
   { to: PATHS.MERCHANT_SERVICES, label: 'My Services' },
+  { to: PATHS.MERCHANT_SURPRISES, label: 'My Surprises' },
   { to: PATHS.MERCHANT_STORES, label: 'My Stores' },
   { to: PATHS.MERCHANT_ANALYTICS, label: 'Analytics' },
   { to: PATHS.MERCHANT_LOYALTY_ANALYTICS, label: 'Loyalty' },

--- a/web/src/hooks/useSurprises.ts
+++ b/web/src/hooks/useSurprises.ts
@@ -1,0 +1,197 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiGet, apiPost, apiPut, apiDelete } from '@/services/api';
+import type {
+  AISurpriseSuggestion,
+  CreateSurpriseDealPayload,
+  MerchantSurpriseDeal,
+  NearbySurprise,
+  RevealHistoryItem,
+  SurpriseAnalytics,
+  SurpriseDealDetail,
+  SurpriseRevealResponse,
+} from '@/types/surprises';
+
+const KEYS = {
+  nearby: (lat: number, lng: number, radius: number) =>
+    ['surprises', 'nearby', lat, lng, radius] as const,
+  deal: (dealId: number) => ['surprises', 'deal', dealId] as const,
+  myHistory: (page: number) => ['surprises', 'my-history', page] as const,
+  merchantList: () => ['merchant', 'surprises'] as const,
+  merchantAnalytics: (dealId: number) =>
+    ['merchant', 'surprises', 'analytics', dealId] as const,
+};
+
+// ─── Consumer hooks ────────────────────────────────────────────────────────────
+
+export const useNearbySurprises = (
+  lat: number | null,
+  lng: number | null,
+  radius = 10,
+) => {
+  return useQuery({
+    queryKey: KEYS.nearby(lat ?? 0, lng ?? 0, radius),
+    queryFn: async () => {
+      const res = await apiGet<{ surprises: NearbySurprise[]; count: number }>(
+        `/surprises/nearby?lat=${lat}&lng=${lng}&radius=${radius}`,
+      );
+      if (!res.success) throw new Error(res.error ?? 'Failed to load surprises');
+      return res.data!;
+    },
+    enabled: lat !== null && lng !== null,
+    // Poll every 60 s so RANDOM_DROP slot counts stay fresh
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+};
+
+export const useRevealSurprise = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      dealId,
+      lat,
+      lng,
+    }: {
+      dealId: number;
+      lat?: number;
+      lng?: number;
+    }) =>
+      apiPost<SurpriseRevealResponse, { lat?: number; lng?: number }>(
+        `/surprises/${dealId}/reveal`,
+        { lat, lng },
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['surprises'] });
+    },
+  });
+};
+
+export const useSurpriseDeal = (dealId: number | null) => {
+  return useQuery({
+    queryKey: KEYS.deal(dealId ?? 0),
+    queryFn: async () => {
+      const res = await apiGet<SurpriseDealDetail>(`/surprises/${dealId}`);
+      if (!res.success) throw new Error(res.error ?? 'Failed to load deal');
+      return res.data!;
+    },
+    enabled: dealId !== null,
+    staleTime: 30_000,
+  });
+};
+
+export const useRedeemSurprise = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (dealId: number) =>
+      apiPost<{ message: string }, Record<string, never>>(
+        `/surprises/${dealId}/redeem`,
+        {},
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['surprises'] });
+    },
+  });
+};
+
+export const useMyRevealHistory = (page = 1, limit = 20) => {
+  return useQuery({
+    queryKey: KEYS.myHistory(page),
+    queryFn: async () => {
+      const res = await apiGet<{
+        reveals: RevealHistoryItem[];
+        total: number;
+        page: number;
+        limit: number;
+      }>(`/surprises/my/reveals?page=${page}&limit=${limit}`);
+      if (!res.success) throw new Error(res.error ?? 'Failed to load history');
+      return res.data!;
+    },
+    staleTime: 60_000,
+  });
+};
+
+// ─── Merchant hooks ────────────────────────────────────────────────────────────
+
+export const useMerchantSurprises = () => {
+  return useQuery({
+    queryKey: KEYS.merchantList(),
+    queryFn: async () => {
+      const res = await apiGet<{ deals: MerchantSurpriseDeal[]; count: number }>(
+        '/merchant/surprises',
+      );
+      if (!res.success) throw new Error(res.error ?? 'Failed to load surprises');
+      return res.data!;
+    },
+    staleTime: 30_000,
+  });
+};
+
+export const useCreateSurpriseDeal = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateSurpriseDealPayload) =>
+      apiPost<{ message: string; deal: MerchantSurpriseDeal }, CreateSurpriseDealPayload>(
+        '/merchant/surprises',
+        payload,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.merchantList() });
+    },
+  });
+};
+
+export const useUpdateSurpriseDeal = (dealId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: Partial<CreateSurpriseDealPayload>) =>
+      apiPut<{ message: string; deal: MerchantSurpriseDeal }, Partial<CreateSurpriseDealPayload>>(
+        `/merchant/surprises/${dealId}`,
+        payload,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.merchantList() });
+    },
+  });
+};
+
+export const useDeactivateSurpriseDeal = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (dealId: number) =>
+      apiDelete<{ message: string }>(`/merchant/surprises/${dealId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.merchantList() });
+    },
+  });
+};
+
+export const useSurpriseAnalytics = (dealId: number | null) => {
+  return useQuery({
+    queryKey: KEYS.merchantAnalytics(dealId ?? 0),
+    queryFn: async () => {
+      const res = await apiGet<SurpriseAnalytics>(
+        `/merchant/surprises/${dealId}/analytics`,
+      );
+      if (!res.success) throw new Error(res.error ?? 'Failed to load analytics');
+      return res.data!;
+    },
+    enabled: dealId !== null,
+    staleTime: 60_000,
+  });
+};
+
+export const useGenerateSurpriseAI = () => {
+  return useMutation({
+    mutationFn: ({
+      intent,
+      surpriseType,
+    }: {
+      intent: string;
+      surpriseType?: string;
+    }) =>
+      apiPost<{ suggestion: AISurpriseSuggestion }, { intent: string; surpriseType?: string }>(
+        '/ai/deals/surprise/generate',
+        { intent, surpriseType },
+      ),
+  });
+};

--- a/web/src/pages/MyRevealHistoryPage.tsx
+++ b/web/src/pages/MyRevealHistoryPage.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { History, ChevronLeft, ChevronRight, CheckCircle2, Clock, XCircle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { ProtectedRoute } from '@/routing/ProtectedRoute';
+import { Button } from '@/components/common/Button';
+import { useMyRevealHistory } from '@/hooks/useSurprises';
+import { PATHS } from '@/routing/paths';
+import { cn } from '@/lib/utils';
+import type { RevealHistoryItem, SurpriseType } from '@/types/surprises';
+
+const TYPE_LABELS: Record<SurpriseType, string> = {
+  LOCATION_BASED: 'Location',
+  TIME_BASED: 'Time',
+  ENGAGEMENT_BASED: 'Check-in',
+  RANDOM_DROP: 'Random Drop',
+};
+
+function HistoryCard({ item }: { item: RevealHistoryItem }) {
+  const expired = !item.redeemed && new Date(item.expiresAt) < new Date();
+  const discount = item.deal.discountPercentage
+    ? `${item.deal.discountPercentage}% off`
+    : item.deal.discountAmount
+      ? `$${item.deal.discountAmount} off`
+      : null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="flex items-start gap-4 rounded-xl border border-neutral-200 bg-white p-4 shadow-sm"
+    >
+      {/* Logo / icon */}
+      <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-neutral-100">
+        {item.deal.merchant.logoUrl ? (
+          <img
+            src={item.deal.merchant.logoUrl}
+            alt={item.deal.merchant.businessName}
+            className="h-full w-full rounded-xl object-cover"
+          />
+        ) : (
+          <span className="text-xl">🎁</span>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="truncate font-semibold text-neutral-900">{item.deal.title}</p>
+            <p className="text-xs text-neutral-500">{item.deal.merchant.businessName}</p>
+          </div>
+          {discount && (
+            <span className="flex-shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-xs font-bold text-green-700">
+              {discount}
+            </span>
+          )}
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-neutral-400">
+          <span className="rounded-full bg-neutral-100 px-2 py-0.5 font-medium">
+            {TYPE_LABELS[item.deal.surpriseType]}
+          </span>
+          <span>Revealed {new Date(item.revealedAt).toLocaleDateString()}</span>
+        </div>
+
+        {/* Status */}
+        <div className="mt-2">
+          {item.redeemed ? (
+            <span className="flex items-center gap-1 text-xs font-medium text-green-600">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              Redeemed {item.redeemedAt ? new Date(item.redeemedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : ''}
+            </span>
+          ) : expired ? (
+            <span className="flex items-center gap-1 text-xs font-medium text-neutral-400">
+              <XCircle className="h-3.5 w-3.5" />
+              Expired — missed it
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 text-xs font-medium text-amber-600">
+              <Clock className="h-3.5 w-3.5" />
+              Revealed, not yet redeemed
+            </span>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function MyRevealHistoryContent() {
+  const [page, setPage] = useState(1);
+  const { data, isLoading, error } = useMyRevealHistory(page);
+
+  const reveals = data?.reveals ?? [];
+  const total = data?.total ?? 0;
+  const limit = data?.limit ?? 20;
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link
+            to={PATHS.SURPRISES}
+            className="flex items-center gap-1 text-sm font-medium text-brand-primary-600 hover:underline"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Back
+          </Link>
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-bold text-neutral-900">
+              <History className="h-6 w-6 text-brand-primary-500" />
+              My Reveal History
+            </h1>
+            {total > 0 && (
+              <p className="mt-0.5 text-sm text-neutral-500">{total} reveal{total !== 1 ? 's' : ''} total</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-24 animate-pulse rounded-xl bg-neutral-100" />
+          ))}
+        </div>
+      )}
+
+      {/* Error */}
+      {error && !isLoading && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {(error as Error).message}
+        </div>
+      )}
+
+      {/* Empty */}
+      {!isLoading && !error && reveals.length === 0 && (
+        <div className="rounded-2xl border-2 border-dashed border-neutral-200 py-20 text-center">
+          <span className="text-5xl">🎁</span>
+          <h3 className="mt-3 text-xl font-bold text-neutral-700">No reveals yet</h3>
+          <p className="mt-1 text-neutral-500">Start exploring nearby surprises.</p>
+          <Link to={PATHS.SURPRISES} className="mt-4 inline-block">
+            <Button size="sm" className="rounded-full">Browse Surprises</Button>
+          </Link>
+        </div>
+      )}
+
+      {/* List */}
+      {!isLoading && reveals.length > 0 && (
+        <>
+          <div className="space-y-3">
+            {reveals.map((item) => (
+              <HistoryCard key={item.id} item={item} />
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="mt-6 flex items-center justify-center gap-3">
+              <Button
+                variant="secondary"
+                size="sm"
+                className="rounded-full"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm text-neutral-500">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="secondary"
+                size="sm"
+                className="rounded-full"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export const MyRevealHistoryPage = () => (
+  <ProtectedRoute>
+    <MyRevealHistoryContent />
+  </ProtectedRoute>
+);

--- a/web/src/pages/SurprisesPage.tsx
+++ b/web/src/pages/SurprisesPage.tsx
@@ -1,0 +1,459 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { MapPin, Clock, Sparkles, Gift, AlertCircle, RefreshCw, History } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { ProtectedRoute } from '@/routing/ProtectedRoute';
+import { Button } from '@/components/common/Button';
+import { useToast } from '@/hooks/use-toast';
+import { useNearbySurprises, useRevealSurprise, useRedeemSurprise } from '@/hooks/useSurprises';
+import { PATHS } from '@/routing/paths';
+import { cn } from '@/lib/utils';
+import type { NearbySurprise, SurpriseDeal, SurpriseType } from '@/types/surprises';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDistance(m: number) {
+  return m >= 1000 ? `${(m / 1000).toFixed(1)} km` : `${Math.round(m)} m`;
+}
+
+function useCountdown(target: string | undefined) {
+  const [remaining, setRemaining] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!target) return;
+    const tick = () => setRemaining(Math.max(0, new Date(target).getTime() - Date.now()));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [target]);
+
+  if (remaining === null) return null;
+  const s = Math.floor(remaining / 1000);
+  const m = Math.floor(s / 60);
+  const h = Math.floor(m / 60);
+  if (h > 0) return `${h}h ${m % 60}m`;
+  if (m > 0) return `${m}m ${s % 60}s`;
+  return `${s}s`;
+}
+
+const TYPE_LABELS: Record<SurpriseType, string> = {
+  LOCATION_BASED: 'Location',
+  TIME_BASED: 'Time',
+  ENGAGEMENT_BASED: 'Check-in',
+  RANDOM_DROP: 'Random Drop',
+};
+
+const TYPE_COLORS: Record<SurpriseType, string> = {
+  LOCATION_BASED: 'bg-blue-100 text-blue-700',
+  TIME_BASED: 'bg-purple-100 text-purple-700',
+  ENGAGEMENT_BASED: 'bg-orange-100 text-orange-700',
+  RANDOM_DROP: 'bg-pink-100 text-pink-700',
+};
+
+// ─── Revealed deal overlay ─────────────────────────────────────────────────────
+
+function RevealedDealCard({
+  deal,
+  expiresAt,
+  dealId,
+  onRedeemed,
+  onClose,
+}: {
+  deal: SurpriseDeal;
+  expiresAt: string;
+  dealId: number;
+  onRedeemed: () => void;
+  onClose: () => void;
+}) {
+  const { toast } = useToast();
+  const redeem = useRedeemSurprise();
+  const countdown = useCountdown(expiresAt);
+  const [confirming, setConfirming] = useState(false);
+
+  const handleRedeem = () => {
+    redeem.mutate(dealId, {
+      onSuccess: () => {
+        toast({ title: 'Deal redeemed!', description: 'Show this screen to the merchant.' });
+        onRedeemed();
+      },
+      onError: (e) => toast({ title: 'Redemption failed', description: e.message, variant: 'destructive' }),
+    });
+  };
+
+  const discount = deal.discountPercentage
+    ? `${deal.discountPercentage}% off`
+    : deal.discountAmount
+      ? `$${deal.discountAmount} off`
+      : null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ y: 60, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 60, opacity: 0 }}
+        transition={{ type: 'spring', damping: 25 }}
+        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between">
+          <div>
+            <span className="text-2xl">{deal.category?.icon}</span>
+            <h2 className="mt-1 text-2xl font-bold text-neutral-900">{deal.title}</h2>
+            <p className="text-sm text-neutral-500">{deal.merchant.businessName}</p>
+          </div>
+          {discount && (
+            <span className="ml-2 rounded-full bg-green-100 px-3 py-1 text-lg font-bold text-green-700">
+              {discount}
+            </span>
+          )}
+        </div>
+
+        <p className="mt-3 text-sm text-neutral-600">{deal.description}</p>
+
+        <div className="mt-4 rounded-xl bg-amber-50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">How to redeem</p>
+          <p className="mt-0.5 text-sm text-amber-800">{deal.redemptionInstructions}</p>
+        </div>
+
+        {countdown !== null && (
+          <div className="mt-3 flex items-center gap-2 text-sm text-neutral-500">
+            <Clock className="h-4 w-4 flex-shrink-0 text-red-400" />
+            <span>
+              Expires in <span className="font-semibold text-red-600">{countdown}</span>
+            </span>
+          </div>
+        )}
+
+        {confirming ? (
+          <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4">
+            <p className="text-sm font-medium text-amber-800">
+              Are you sure? This cannot be undone.
+            </p>
+            <div className="mt-3 flex gap-2">
+              <Button
+                size="sm"
+                className="flex-1 rounded-full"
+                onClick={handleRedeem}
+                disabled={redeem.isPending}
+              >
+                {redeem.isPending ? 'Redeeming…' : 'Yes, redeem now'}
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                className="flex-1 rounded-full"
+                onClick={() => setConfirming(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button
+            size="md"
+            className="mt-4 w-full rounded-full"
+            onClick={() => setConfirming(true)}
+          >
+            Redeem Now
+          </Button>
+        )}
+      </motion.div>
+    </motion.div>
+  );
+}
+
+// ─── Mystery card ──────────────────────────────────────────────────────────────
+
+function SurpriseCard({
+  surprise,
+  userLat,
+  userLng,
+  onRevealed,
+}: {
+  surprise: NearbySurprise;
+  userLat: number;
+  userLng: number;
+  onRevealed: (deal: SurpriseDeal, expiresAt: string) => void;
+}) {
+  const { toast } = useToast();
+  const reveal = useRevealSurprise();
+  const redeemCountdown = useCountdown(surprise.isRevealed ? surprise.expiresAt : undefined);
+  const revealCountdown = useCountdown(
+    surprise.surpriseType === 'TIME_BASED' && !surprise.isRevealed ? surprise.revealAt : undefined,
+  );
+
+  const handleReveal = () => {
+    reveal.mutate(
+      { dealId: surprise.id, lat: userLat, lng: userLng },
+      {
+        onSuccess: (res) => {
+          if (!res.success || !res.data) {
+            toast({ title: 'Could not reveal', description: res.error ?? 'Try again', variant: 'destructive' });
+            return;
+          }
+          onRevealed(res.data.deal, res.data.expiresAt);
+        },
+        onError: (e) => toast({ title: 'Could not reveal', description: e.message, variant: 'destructive' }),
+      },
+    );
+  };
+
+  const isExpired = surprise.isExpired;
+  const isRevealed = surprise.isRevealed;
+  const isRedeemed = surprise.isRedeemed;
+
+  // Determine CTA state per the API's state matrix
+  let ctaContent: React.ReactNode;
+  if (!isRevealed && !isExpired) {
+    ctaContent = (
+      <Button
+        size="sm"
+        className="w-full rounded-full"
+        onClick={handleReveal}
+        disabled={reveal.isPending}
+      >
+        {reveal.isPending ? 'Revealing…' : 'Reveal 🎁'}
+      </Button>
+    );
+  } else if (isRevealed && !isExpired && !isRedeemed) {
+    ctaContent = (
+      <Button size="sm" className="w-full rounded-full bg-green-600 hover:bg-green-700" onClick={handleReveal}>
+        View & Redeem
+      </Button>
+    );
+  } else if (isRevealed && isRedeemed) {
+    ctaContent = (
+      <div className="w-full rounded-full bg-neutral-100 py-1.5 text-center text-sm font-semibold text-neutral-500">
+        Redeemed ✓
+      </div>
+    );
+  } else if (isExpired) {
+    ctaContent = (
+      <div className="w-full rounded-full bg-neutral-100 py-1.5 text-center text-sm font-semibold text-neutral-400">
+        Expired
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn(
+        'relative overflow-hidden rounded-2xl border bg-white shadow-sm transition-shadow hover:shadow-md',
+        isExpired ? 'opacity-60' : '',
+        isRevealed && !isRedeemed && !isExpired ? 'border-green-300 ring-1 ring-green-200' : 'border-neutral-200',
+      )}
+    >
+      {/* Header gradient */}
+      <div className="relative h-24 bg-gradient-to-br from-brand-primary-500/20 via-purple-500/10 to-pink-500/20 flex items-center justify-center">
+        {isRevealed ? (
+          <Gift className="h-10 w-10 text-brand-primary-500" />
+        ) : (
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/60 backdrop-blur-sm">
+            <span className="text-2xl">🎁</span>
+          </div>
+        )}
+        <div className="absolute left-3 top-3">
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 text-xs font-semibold',
+              TYPE_COLORS[surprise.surpriseType],
+            )}
+          >
+            {TYPE_LABELS[surprise.surpriseType]}
+          </span>
+        </div>
+        {surprise.merchantLogoUrl && (
+          <img
+            src={surprise.merchantLogoUrl}
+            alt={surprise.merchantName}
+            className="absolute right-3 top-3 h-8 w-8 rounded-full border border-white/60 object-cover"
+          />
+        )}
+      </div>
+
+      <div className="p-4">
+        <p className="text-sm font-medium text-neutral-900 line-clamp-2 italic">
+          "{surprise.hint}"
+        </p>
+        <p className="mt-1 text-xs text-neutral-500">{surprise.merchantName}</p>
+
+        <div className="mt-2 flex items-center gap-3 text-xs text-neutral-400">
+          <span className="flex items-center gap-1">
+            <MapPin className="h-3 w-3" />
+            {formatDistance(surprise.distanceMeters)}
+          </span>
+
+          {/* LOCATION_BASED: proximity hint */}
+          {surprise.surpriseType === 'LOCATION_BASED' && surprise.revealRadiusMeters && !isRevealed && (
+            <span className="text-blue-600">
+              {surprise.distanceMeters <= surprise.revealRadiusMeters
+                ? 'Close enough!'
+                : `Get within ${formatDistance(surprise.revealRadiusMeters)}`}
+            </span>
+          )}
+
+          {/* TIME_BASED: countdown to reveal */}
+          {surprise.surpriseType === 'TIME_BASED' && revealCountdown && !isRevealed && (
+            <span className="flex items-center gap-1 text-purple-600">
+              <Clock className="h-3 w-3" />
+              Unlocks in {revealCountdown}
+            </span>
+          )}
+
+          {/* Revealed: countdown to expiry */}
+          {isRevealed && !isExpired && !isRedeemed && redeemCountdown && (
+            <span className="flex items-center gap-1 text-red-500">
+              <Clock className="h-3 w-3" />
+              {redeemCountdown} left
+            </span>
+          )}
+        </div>
+
+        <div className="mt-3">{ctaContent}</div>
+      </div>
+    </motion.div>
+  );
+}
+
+// ─── Main page ─────────────────────────────────────────────────────────────────
+
+function SurprisesContent() {
+  const { toast } = useToast();
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [revealedDeal, setRevealedDeal] = useState<{
+    deal: SurpriseDeal;
+    expiresAt: string;
+    dealId: number;
+  } | null>(null);
+  const locationRequested = useRef(false);
+
+  const { data, isLoading, error, refetch } = useNearbySurprises(
+    coords?.lat ?? null,
+    coords?.lng ?? null,
+  );
+
+  useEffect(() => {
+    if (locationRequested.current) return;
+    locationRequested.current = true;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+      () => setLocationError('Location access denied. Enable location to see nearby surprises.'),
+    );
+  }, []);
+
+  const surprises = data?.surprises ?? [];
+
+  return (
+    <div className="mx-auto max-w-screen-xl px-4 py-8">
+      {/* Header */}
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-3xl font-bold text-neutral-900">
+            <Sparkles className="h-7 w-7 text-brand-primary-500" />
+            Nearby Surprises
+          </h1>
+          <p className="mt-1 text-neutral-500">Mystery deals hidden until you unlock them.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link to={PATHS.MY_REVEAL_HISTORY}>
+            <Button variant="secondary" size="sm" className="rounded-full">
+              <History className="mr-1.5 h-4 w-4" />
+              My History
+            </Button>
+          </Link>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="rounded-full"
+            onClick={() => refetch()}
+            disabled={isLoading}
+          >
+            <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Location error */}
+      {locationError && (
+        <div className="mb-6 flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4">
+          <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-500" />
+          <p className="text-sm text-amber-800">{locationError}</p>
+        </div>
+      )}
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-52 animate-pulse rounded-2xl bg-neutral-100" />
+          ))}
+        </div>
+      )}
+
+      {/* Error */}
+      {error && !isLoading && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {(error as Error).message}
+        </div>
+      )}
+
+      {/* Empty */}
+      {!isLoading && !error && surprises.length === 0 && coords && (
+        <div className="rounded-2xl border-2 border-dashed border-neutral-200 py-20 text-center">
+          <span className="text-5xl">🎁</span>
+          <h3 className="mt-3 text-xl font-bold text-neutral-700">No surprises nearby</h3>
+          <p className="mt-1 text-neutral-500">Check back soon — merchants add new surprises regularly.</p>
+        </div>
+      )}
+
+      {/* Cards */}
+      {!isLoading && surprises.length > 0 && coords && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {surprises.map((surprise) => (
+            <SurpriseCard
+              key={surprise.id}
+              surprise={surprise}
+              userLat={coords.lat}
+              userLng={coords.lng}
+              onRevealed={(deal, expiresAt) =>
+                setRevealedDeal({ deal, expiresAt, dealId: surprise.id })
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Revealed deal overlay */}
+      <AnimatePresence>
+        {revealedDeal && (
+          <RevealedDealCard
+            deal={revealedDeal.deal}
+            expiresAt={revealedDeal.expiresAt}
+            dealId={revealedDeal.dealId}
+            onRedeemed={() => {
+              setRevealedDeal(null);
+              refetch();
+            }}
+            onClose={() => setRevealedDeal(null)}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export const SurprisesPage = () => (
+  <ProtectedRoute>
+    <SurprisesContent />
+  </ProtectedRoute>
+);

--- a/web/src/pages/merchant/MerchantMySurprisesPage.tsx
+++ b/web/src/pages/merchant/MerchantMySurprisesPage.tsx
@@ -1,0 +1,198 @@
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { PlusCircle, Gift, BarChart2, Trash2, Users, Layers } from 'lucide-react';
+import { MerchantProtectedRoute } from '@/components/auth/MerchantProtectedRoute';
+import { Button } from '@/components/common/Button';
+import { PATHS } from '@/routing/paths';
+import { cn } from '@/lib/utils';
+import { useToast } from '@/hooks/use-toast';
+import { useMerchantSurprises, useDeactivateSurpriseDeal } from '@/hooks/useSurprises';
+import type { MerchantSurpriseDeal, SurpriseType } from '@/types/surprises';
+
+const TYPE_LABELS: Record<SurpriseType, string> = {
+  LOCATION_BASED: 'Location',
+  TIME_BASED: 'Time',
+  ENGAGEMENT_BASED: 'Check-in',
+  RANDOM_DROP: 'Random Drop',
+};
+
+const TYPE_COLORS: Record<SurpriseType, string> = {
+  LOCATION_BASED: 'bg-blue-100 text-blue-700',
+  TIME_BASED: 'bg-purple-100 text-purple-700',
+  ENGAGEMENT_BASED: 'bg-orange-100 text-orange-700',
+  RANDOM_DROP: 'bg-pink-100 text-pink-700',
+};
+
+function SurpriseDealCard({
+  deal,
+  onDeactivate,
+}: {
+  deal: MerchantSurpriseDeal;
+  onDeactivate: (id: number) => void;
+}) {
+  const isActive = deal.isActive && new Date(deal.endTime) > new Date();
+  const slotsFull =
+    deal.surpriseTotalSlots !== null && deal.surpriseSlotsUsed >= deal.surpriseTotalSlots;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm"
+    >
+      {/* Header */}
+      <div className="relative h-28 bg-gradient-to-br from-brand-primary-500/20 via-purple-500/10 to-pink-500/20 flex items-center justify-center">
+        <span className="text-4xl">{deal.category?.icon ?? '🎁'}</span>
+        <div className="absolute left-3 top-3 flex gap-1.5">
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 text-xs font-semibold',
+              TYPE_COLORS[deal.surpriseType],
+            )}
+          >
+            {TYPE_LABELS[deal.surpriseType]}
+          </span>
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 text-xs font-semibold',
+              isActive && !slotsFull ? 'bg-green-100 text-green-700' : 'bg-neutral-100 text-neutral-500',
+            )}
+          >
+            {!isActive ? 'Inactive' : slotsFull ? 'Full' : 'Active'}
+          </span>
+        </div>
+      </div>
+
+      <div className="p-4">
+        <h3 className="line-clamp-1 font-bold text-neutral-900">{deal.title}</h3>
+        {deal.surpriseHint && (
+          <p className="mt-0.5 line-clamp-1 text-xs italic text-neutral-400">"{deal.surpriseHint}"</p>
+        )}
+
+        {/* Stats */}
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <div className="flex items-center gap-2 rounded-lg bg-neutral-50 px-2.5 py-2">
+            <Users className="h-4 w-4 text-brand-primary-400" />
+            <div>
+              <p className="text-xs text-neutral-400">Reveals</p>
+              <p className="text-sm font-bold text-neutral-800">{deal.revealsCount}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 rounded-lg bg-neutral-50 px-2.5 py-2">
+            <Layers className="h-4 w-4 text-brand-primary-400" />
+            <div>
+              <p className="text-xs text-neutral-400">Slots</p>
+              <p className="text-sm font-bold text-neutral-800">
+                {deal.surpriseTotalSlots === null
+                  ? `${deal.surpriseSlotsUsed} / ∞`
+                  : `${deal.surpriseSlotsUsed} / ${deal.surpriseTotalSlots}`}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-2 text-xs text-neutral-400">
+          {new Date(deal.startTime).toLocaleDateString()} — {new Date(deal.endTime).toLocaleDateString()}
+        </p>
+
+        {/* Actions */}
+        <div className="mt-3 flex items-center gap-2">
+          <Link
+            to={PATHS.MERCHANT_SURPRISES_ANALYTICS.replace(':dealId', String(deal.id))}
+            className="flex-1"
+          >
+            <Button size="sm" className="w-full rounded-lg">
+              <BarChart2 className="mr-1.5 h-3.5 w-3.5" />
+              Analytics
+            </Button>
+          </Link>
+          {isActive && (
+            <button
+              onClick={() => onDeactivate(deal.id)}
+              className="rounded-lg border border-red-200 p-2 text-red-500 transition-colors hover:bg-red-50"
+              title="Deactivate"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function MerchantMySurprisesContent() {
+  const { data, isLoading, error } = useMerchantSurprises();
+  const deactivate = useDeactivateSurpriseDeal();
+  const { toast } = useToast();
+
+  const deals = data?.deals ?? [];
+
+  const handleDeactivate = (dealId: number) => {
+    if (!confirm('Deactivate this surprise deal? It will expire immediately.')) return;
+    deactivate.mutate(dealId, {
+      onSuccess: () => toast({ title: 'Surprise deal deactivated' }),
+      onError: (e) => toast({ title: 'Error', description: e.message, variant: 'destructive' }),
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-brand-primary-500 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+          {(error as Error).message}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-screen-xl px-6 py-8">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-neutral-900">My Surprise Deals</h1>
+          <p className="mt-1 text-neutral-500">
+            Mystery deals that unlock based on location, time, check-ins, or random drops.
+          </p>
+        </div>
+        <Link to={PATHS.MERCHANT_SURPRISES_CREATE}>
+          <Button size="md" className="rounded-full">
+            <PlusCircle className="mr-2 h-4 w-4" />
+            Create Surprise
+          </Button>
+        </Link>
+      </div>
+
+      {deals.length === 0 ? (
+        <div className="rounded-2xl border-2 border-dashed border-neutral-200 py-16 text-center">
+          <Gift className="mx-auto mb-3 h-10 w-10 text-neutral-300" />
+          <h3 className="text-xl font-bold text-neutral-700">No surprise deals yet</h3>
+          <p className="mt-1 text-neutral-500">Create a mystery deal to engage nearby customers.</p>
+          <Link to={PATHS.MERCHANT_SURPRISES_CREATE} className="mt-4 inline-block">
+            <Button size="sm" className="rounded-full">Create Your First Surprise</Button>
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {deals.map((deal) => (
+            <SurpriseDealCard key={deal.id} deal={deal} onDeactivate={handleDeactivate} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const MerchantMySurprisesPage = () => (
+  <MerchantProtectedRoute fallbackMessage="Only merchants can manage surprise deals.">
+    <MerchantMySurprisesContent />
+  </MerchantProtectedRoute>
+);

--- a/web/src/pages/merchant/SurpriseAnalyticsPage.tsx
+++ b/web/src/pages/merchant/SurpriseAnalyticsPage.tsx
@@ -1,0 +1,182 @@
+import { useParams, Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { ArrowLeft, Eye, ShoppingBag, TrendingUp, Layers, Clock } from 'lucide-react';
+import { MerchantProtectedRoute } from '@/components/auth/MerchantProtectedRoute';
+import { PATHS } from '@/routing/paths';
+import { useSurpriseAnalytics } from '@/hooks/useSurprises';
+import { cn } from '@/lib/utils';
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  color,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string | number;
+  sub?: string;
+  color: string;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm"
+    >
+      <div className={cn('mb-3 inline-flex rounded-lg p-2', color)}>
+        <Icon className="h-5 w-5" />
+      </div>
+      <p className="text-2xl font-bold text-neutral-900">{value}</p>
+      <p className="mt-0.5 text-sm font-medium text-neutral-600">{label}</p>
+      {sub && <p className="mt-0.5 text-xs text-neutral-400">{sub}</p>}
+    </motion.div>
+  );
+}
+
+function SurpriseAnalyticsContent() {
+  const { dealId } = useParams<{ dealId: string }>();
+  const { data, isLoading, error } = useSurpriseAnalytics(dealId ? Number(dealId) : null);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-brand-primary-500 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {(error as Error)?.message ?? 'Failed to load analytics'}
+        </div>
+      </div>
+    );
+  }
+
+  const { deal, analytics, recentReveals } = data;
+
+  return (
+    <div className="mx-auto max-w-screen-lg px-4 py-8">
+      {/* Back link */}
+      <Link
+        to={PATHS.MERCHANT_SURPRISES}
+        className="inline-flex items-center gap-1 text-sm font-medium text-brand-primary-600 hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to My Surprises
+      </Link>
+
+      {/* Header */}
+      <div className="mt-4">
+        <h1 className="text-2xl font-bold text-neutral-900">{deal.title}</h1>
+        <p className="mt-0.5 text-sm text-neutral-500">
+          {new Date(deal.startTime).toLocaleDateString()} — {new Date(deal.endTime).toLocaleDateString()} ·{' '}
+          <span className="font-medium">{deal.surpriseType.replace('_', ' ')}</span>
+        </p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={Eye}
+          label="Total Reveals"
+          value={analytics.totalReveals}
+          color="bg-blue-100 text-blue-600"
+        />
+        <StatCard
+          icon={ShoppingBag}
+          label="Total Redeemed"
+          value={analytics.totalRedeemed}
+          color="bg-green-100 text-green-600"
+        />
+        <StatCard
+          icon={TrendingUp}
+          label="Conversion Rate"
+          value={analytics.conversionRate}
+          color="bg-purple-100 text-purple-600"
+        />
+        <StatCard
+          icon={Layers}
+          label="Slots Used"
+          value={
+            analytics.slotsTotal
+              ? `${analytics.slotsUsed} / ${analytics.slotsTotal}`
+              : `${analytics.slotsUsed} / ∞`
+          }
+          sub={
+            analytics.slotsRemaining !== null
+              ? `${analytics.slotsRemaining} remaining`
+              : 'Unlimited slots'
+          }
+          color="bg-orange-100 text-orange-600"
+        />
+      </div>
+
+      {/* Recent reveals */}
+      {recentReveals.length > 0 && (
+        <div className="mt-8">
+          <h2 className="mb-4 text-lg font-bold text-neutral-900">Recent Reveals</h2>
+          <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-neutral-100 bg-neutral-50">
+                  <th className="px-4 py-3 text-left font-semibold text-neutral-600">Revealed At</th>
+                  <th className="px-4 py-3 text-left font-semibold text-neutral-600">Status</th>
+                  <th className="px-4 py-3 text-left font-semibold text-neutral-600">Redeemed At</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentReveals.map((reveal, i) => (
+                  <motion.tr
+                    key={i}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: i * 0.03 }}
+                    className={cn(
+                      'border-b border-neutral-50',
+                      i % 2 === 0 ? 'bg-white' : 'bg-neutral-50/50',
+                    )}
+                  >
+                    <td className="px-4 py-3 text-neutral-700">
+                      <span className="flex items-center gap-1.5">
+                        <Clock className="h-3.5 w-3.5 text-neutral-400" />
+                        {new Date(reveal.revealedAt).toLocaleString()}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={cn(
+                          'rounded-full px-2.5 py-0.5 text-xs font-semibold',
+                          reveal.redeemed
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-amber-100 text-amber-700',
+                        )}
+                      >
+                        {reveal.redeemed ? 'Redeemed' : 'Revealed only'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-neutral-500">
+                      {reveal.redeemedAt
+                        ? new Date(reveal.redeemedAt).toLocaleString()
+                        : '—'}
+                    </td>
+                  </motion.tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const SurpriseAnalyticsPage = () => (
+  <MerchantProtectedRoute fallbackMessage="Only merchants can view surprise analytics.">
+    <SurpriseAnalyticsContent />
+  </MerchantProtectedRoute>
+);

--- a/web/src/pages/merchant/SurpriseCreatePage.tsx
+++ b/web/src/pages/merchant/SurpriseCreatePage.tsx
@@ -1,0 +1,412 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Sparkles, Loader2 } from 'lucide-react';
+import { MerchantProtectedRoute } from '@/components/auth/MerchantProtectedRoute';
+import { Button } from '@/components/common/Button';
+import { PATHS } from '@/routing/paths';
+import { useToast } from '@/hooks/use-toast';
+import { useCreateSurpriseDeal, useGenerateSurpriseAI } from '@/hooks/useSurprises';
+import type { CreateSurpriseDealPayload, SurpriseType } from '@/types/surprises';
+import { cn } from '@/lib/utils';
+
+const SURPRISE_TYPES: { value: SurpriseType; label: string; description: string }[] = [
+  {
+    value: 'LOCATION_BASED',
+    label: 'Location',
+    description: 'Reveal when user is within a set radius',
+  },
+  {
+    value: 'TIME_BASED',
+    label: 'Time',
+    description: 'Reveal automatically at a specific date & time',
+  },
+  {
+    value: 'ENGAGEMENT_BASED',
+    label: 'Check-in',
+    description: 'Reveal after user checks in at your location',
+  },
+  {
+    value: 'RANDOM_DROP',
+    label: 'Random Drop',
+    description: 'First-come-first-served from a limited slot pool',
+  },
+];
+
+interface FormState {
+  title: string;
+  description: string;
+  categoryId: string;
+  dealTypeId: string;
+  startTime: string;
+  endTime: string;
+  redemptionInstructions: string;
+  surpriseType: SurpriseType;
+  surpriseHint: string;
+  discountPercentage: string;
+  discountAmount: string;
+  revealRadiusMeters: string;
+  revealAt: string;
+  revealDurationMinutes: string;
+  surpriseTotalSlots: string;
+}
+
+const EMPTY_FORM: FormState = {
+  title: '',
+  description: '',
+  categoryId: '',
+  dealTypeId: '',
+  startTime: '',
+  endTime: '',
+  redemptionInstructions: '',
+  surpriseType: 'LOCATION_BASED',
+  surpriseHint: '',
+  discountPercentage: '',
+  discountAmount: '',
+  revealRadiusMeters: '',
+  revealAt: '',
+  revealDurationMinutes: '60',
+  surpriseTotalSlots: '',
+};
+
+function Field({
+  label,
+  required,
+  children,
+  hint,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+  hint?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-semibold text-neutral-700">
+        {label}
+        {required && <span className="ml-0.5 text-red-500">*</span>}
+      </label>
+      {children}
+      {hint && <p className="text-xs text-neutral-400">{hint}</p>}
+    </div>
+  );
+}
+
+const inputCls =
+  'w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 outline-none focus:border-brand-primary-500 focus:ring-2 focus:ring-brand-primary-500/20 disabled:bg-neutral-50';
+
+function SurpriseCreateInner() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const create = useCreateSurpriseDeal();
+  const generateAI = useGenerateSurpriseAI();
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [aiIntent, setAiIntent] = useState('');
+
+  const set = (field: keyof FormState, value: string) =>
+    setForm((prev) => ({ ...prev, [field]: value }));
+
+  const handleGenerateAI = () => {
+    if (aiIntent.trim().length < 5) {
+      toast({ title: 'Describe your offer', description: 'At least 5 characters needed.', variant: 'destructive' });
+      return;
+    }
+    generateAI.mutate(
+      { intent: aiIntent, surpriseType: form.surpriseType },
+      {
+        onSuccess: (res) => {
+          if (!res.success || !res.data) {
+            toast({ title: 'AI unavailable', description: res.error ?? 'Try again later.', variant: 'destructive' });
+            return;
+          }
+          const s = res.data.suggestion;
+          setForm((prev) => ({
+            ...prev,
+            title: s.title,
+            description: s.description,
+            surpriseHint: s.surpriseHint,
+            redemptionInstructions: s.redemptionInstructions,
+            discountPercentage: s.discountPercentage !== null ? String(s.discountPercentage) : '',
+            discountAmount: s.discountAmount !== null ? String(s.discountAmount) : '',
+            surpriseType: s.suggestedRevealType,
+            revealRadiusMeters: s.suggestedRevealRadiusMeters !== null
+              ? String(s.suggestedRevealRadiusMeters)
+              : '',
+          }));
+          toast({ title: 'AI suggestion applied', description: 'Review and edit before saving.' });
+        },
+        onError: (e) =>
+          toast({ title: 'AI failed', description: e.message, variant: 'destructive' }),
+      },
+    );
+  };
+
+  const handleSubmit = () => {
+    if (!form.title.trim() || !form.description.trim() || !form.startTime || !form.endTime || !form.redemptionInstructions.trim()) {
+      toast({ title: 'Missing required fields', variant: 'destructive' });
+      return;
+    }
+    if (form.surpriseType === 'LOCATION_BASED' && !form.revealRadiusMeters) {
+      toast({ title: 'Reveal radius required for Location-based surprise', variant: 'destructive' });
+      return;
+    }
+    if (form.surpriseType === 'TIME_BASED' && !form.revealAt) {
+      toast({ title: 'Reveal time required for Time-based surprise', variant: 'destructive' });
+      return;
+    }
+
+    const payload: CreateSurpriseDealPayload = {
+      title: form.title.trim(),
+      description: form.description.trim(),
+      categoryId: Number(form.categoryId) || 1,
+      dealTypeId: Number(form.dealTypeId) || 1,
+      startTime: new Date(form.startTime).toISOString(),
+      endTime: new Date(form.endTime).toISOString(),
+      redemptionInstructions: form.redemptionInstructions.trim(),
+      surpriseType: form.surpriseType,
+      surpriseHint: form.surpriseHint.trim() || undefined,
+      discountPercentage: form.discountPercentage ? Number(form.discountPercentage) : undefined,
+      discountAmount: form.discountAmount ? Number(form.discountAmount) : undefined,
+      revealRadiusMeters: form.revealRadiusMeters ? Number(form.revealRadiusMeters) : undefined,
+      revealAt: form.revealAt ? new Date(form.revealAt).toISOString() : undefined,
+      revealDurationMinutes: form.revealDurationMinutes ? Number(form.revealDurationMinutes) : undefined,
+      surpriseTotalSlots: form.surpriseTotalSlots ? Number(form.surpriseTotalSlots) : undefined,
+    };
+
+    create.mutate(payload, {
+      onSuccess: () => {
+        toast({ title: 'Surprise deal created!' });
+        navigate(PATHS.MERCHANT_SURPRISES);
+      },
+      onError: (e) =>
+        toast({ title: 'Create failed', description: e.message, variant: 'destructive' }),
+    });
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <Link
+        to={PATHS.MERCHANT_SURPRISES}
+        className="inline-flex items-center gap-1 text-sm font-medium text-brand-primary-600 hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to My Surprises
+      </Link>
+
+      <h1 className="mt-4 text-2xl font-bold text-neutral-900">Create Surprise Deal</h1>
+      <p className="mt-1 text-sm text-neutral-500">
+        A mystery deal that users reveal by meeting a trigger condition.
+      </p>
+
+      {/* AI Generate section */}
+      <div className="mt-6 rounded-xl border border-brand-primary-200 bg-brand-primary-50 p-4">
+        <p className="text-sm font-semibold text-brand-primary-800">Generate with AI ✨</p>
+        <p className="mt-0.5 text-xs text-brand-primary-600">
+          Describe your offer and we'll fill in the form for you.
+        </p>
+        <div className="mt-3 flex gap-2">
+          <input
+            className={cn(inputCls, 'flex-1 border-brand-primary-200 bg-white')}
+            placeholder="e.g. 20% off all cocktails after 8pm on weekends"
+            value={aiIntent}
+            onChange={(e) => setAiIntent(e.target.value)}
+          />
+          <Button
+            size="sm"
+            className="flex-shrink-0 rounded-full"
+            onClick={handleGenerateAI}
+            disabled={generateAI.isPending}
+          >
+            {generateAI.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-xl border border-neutral-200 bg-white p-6 shadow-sm">
+        <div className="grid gap-5">
+          {/* Surprise type selector */}
+          <Field label="Surprise Type" required>
+            <div className="grid grid-cols-2 gap-2">
+              {SURPRISE_TYPES.map((t) => (
+                <button
+                  key={t.value}
+                  type="button"
+                  onClick={() => set('surpriseType', t.value)}
+                  className={cn(
+                    'rounded-xl border p-3 text-left transition-all',
+                    form.surpriseType === t.value
+                      ? 'border-brand-primary-500 bg-brand-primary-50 ring-1 ring-brand-primary-300'
+                      : 'border-neutral-200 hover:border-neutral-300',
+                  )}
+                >
+                  <p className="text-sm font-semibold text-neutral-900">{t.label}</p>
+                  <p className="mt-0.5 text-xs text-neutral-500">{t.description}</p>
+                </button>
+              ))}
+            </div>
+          </Field>
+
+          {/* Basic info */}
+          <Field label="Title" required>
+            <input
+              className={inputCls}
+              placeholder="e.g. Mystery Happy Hour"
+              value={form.title}
+              onChange={(e) => set('title', e.target.value)}
+            />
+          </Field>
+
+          <Field label="Description" required>
+            <textarea
+              className={cn(inputCls, 'resize-none')}
+              rows={3}
+              placeholder="Full deal description (shown after reveal)"
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+            />
+          </Field>
+
+          <Field label="Hint" hint="Teaser shown to users before they reveal the deal">
+            <input
+              className={inputCls}
+              placeholder="e.g. Something bubbly awaits after sundown… 🍾"
+              value={form.surpriseHint}
+              onChange={(e) => set('surpriseHint', e.target.value)}
+            />
+          </Field>
+
+          <Field label="Redemption Instructions" required>
+            <textarea
+              className={cn(inputCls, 'resize-none')}
+              rows={2}
+              placeholder="e.g. Show this screen to your server before ordering."
+              value={form.redemptionInstructions}
+              onChange={(e) => set('redemptionInstructions', e.target.value)}
+            />
+          </Field>
+
+          {/* Discount */}
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Discount %" hint="Leave blank if not applicable">
+              <input
+                className={inputCls}
+                type="number"
+                min={0}
+                max={100}
+                placeholder="e.g. 30"
+                value={form.discountPercentage}
+                onChange={(e) => set('discountPercentage', e.target.value)}
+              />
+            </Field>
+            <Field label="Discount Amount ($)" hint="Leave blank if not applicable">
+              <input
+                className={inputCls}
+                type="number"
+                min={0}
+                placeholder="e.g. 5"
+                value={form.discountAmount}
+                onChange={(e) => set('discountAmount', e.target.value)}
+              />
+            </Field>
+          </div>
+
+          {/* Schedule */}
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Start Time" required>
+              <input
+                className={inputCls}
+                type="datetime-local"
+                value={form.startTime}
+                onChange={(e) => set('startTime', e.target.value)}
+              />
+            </Field>
+            <Field label="End Time" required>
+              <input
+                className={inputCls}
+                type="datetime-local"
+                value={form.endTime}
+                onChange={(e) => set('endTime', e.target.value)}
+              />
+            </Field>
+          </div>
+
+          {/* Conditional: Location-based */}
+          {form.surpriseType === 'LOCATION_BASED' && (
+            <Field label="Reveal Radius (meters)" required hint="How close the user must be to unlock">
+              <input
+                className={inputCls}
+                type="number"
+                min={10}
+                placeholder="e.g. 100"
+                value={form.revealRadiusMeters}
+                onChange={(e) => set('revealRadiusMeters', e.target.value)}
+              />
+            </Field>
+          )}
+
+          {/* Conditional: Time-based */}
+          {form.surpriseType === 'TIME_BASED' && (
+            <Field label="Reveal At" required hint="Deal becomes unlockable at this exact time">
+              <input
+                className={inputCls}
+                type="datetime-local"
+                value={form.revealAt}
+                onChange={(e) => set('revealAt', e.target.value)}
+              />
+            </Field>
+          )}
+
+          {/* Advanced */}
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Reveal Window (minutes)" hint="How long after reveal user has to redeem (default 60)">
+              <input
+                className={inputCls}
+                type="number"
+                min={1}
+                placeholder="60"
+                value={form.revealDurationMinutes}
+                onChange={(e) => set('revealDurationMinutes', e.target.value)}
+              />
+            </Field>
+            <Field label="Total Slots" hint="Leave blank for unlimited">
+              <input
+                className={inputCls}
+                type="number"
+                min={1}
+                placeholder="e.g. 50"
+                value={form.surpriseTotalSlots}
+                onChange={(e) => set('surpriseTotalSlots', e.target.value)}
+              />
+            </Field>
+          </div>
+        </div>
+
+        <div className="mt-6 flex gap-3">
+          <Button
+            size="md"
+            className="flex-1 rounded-full"
+            onClick={handleSubmit}
+            disabled={create.isPending}
+          >
+            {create.isPending ? 'Creating…' : 'Create Surprise Deal'}
+          </Button>
+          <Link to={PATHS.MERCHANT_SURPRISES}>
+            <Button variant="secondary" size="md" className="rounded-full">
+              Cancel
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const SurpriseCreatePage = () => (
+  <MerchantProtectedRoute fallbackMessage="Only merchants can create surprise deals.">
+    <SurpriseCreateInner />
+  </MerchantProtectedRoute>
+);

--- a/web/src/routing/paths.ts
+++ b/web/src/routing/paths.ts
@@ -85,6 +85,15 @@ export const PATHS = {
   MERCHANT_SERVICES_MANAGE: '/merchant/services/:serviceId',
   MERCHANT_SERVICES_CHECKIN: '/merchant/services/:serviceId/checkin',
 
+  // Merchant Surprises
+  MERCHANT_SURPRISES: '/merchant/surprises',
+  MERCHANT_SURPRISES_CREATE: '/merchant/surprises/create',
+  MERCHANT_SURPRISES_ANALYTICS: '/merchant/surprises/:dealId/analytics',
+
+  // Consumer Surprises
+  SURPRISES: '/surprises',
+  MY_REVEAL_HISTORY: '/surprises/history',
+
   // Events
   EVENT_DETAIL: '/events/:eventId',
   DISCOVER_EVENTS: '/discover/events',

--- a/web/src/types/surprises.ts
+++ b/web/src/types/surprises.ts
@@ -1,0 +1,145 @@
+export type SurpriseType = 'LOCATION_BASED' | 'TIME_BASED' | 'ENGAGEMENT_BASED' | 'RANDOM_DROP';
+
+export interface NearbySurprise {
+  id: number;
+  hint: string;
+  surpriseType: SurpriseType;
+  merchantName: string;
+  merchantLogoUrl: string | null;
+  distanceMeters: number;
+  isRevealed: boolean;
+  isExpired: boolean;
+  isRedeemed: boolean;
+  revealAt?: string;
+  revealRadiusMeters?: number;
+  expiresAt?: string;
+}
+
+export interface SurpriseDeal {
+  id: number;
+  title: string;
+  description: string;
+  discountPercentage: number | null;
+  discountAmount: number | null;
+  redemptionInstructions: string;
+  startTime: string;
+  endTime: string;
+  merchant: {
+    id: number;
+    businessName: string;
+    latitude: number;
+    longitude: number;
+    logoUrl?: string;
+  };
+  category: { name: string; icon: string; color?: string };
+  dealType: { name: string };
+}
+
+export interface SurpriseRevealResponse {
+  message: string;
+  revealId: number;
+  expiresAt: string;
+  deal: SurpriseDeal;
+  alreadyRevealed?: boolean;
+}
+
+export interface SurpriseDealDetail {
+  deal: SurpriseDeal & {
+    merchant: SurpriseDeal['merchant'] & { logoUrl: string | null };
+  };
+  reveal: {
+    revealedAt: string;
+    expiresAt: string;
+    redeemed: boolean;
+    redeemedAt: string | null;
+  };
+}
+
+export interface RevealHistoryItem {
+  id: number;
+  revealedAt: string;
+  expiresAt: string;
+  redeemed: boolean;
+  redeemedAt: string | null;
+  deal: {
+    id: number;
+    title: string;
+    surpriseHint: string;
+    surpriseType: SurpriseType;
+    discountPercentage: number | null;
+    discountAmount: number | null;
+    merchant: {
+      businessName: string;
+      logoUrl: string | null;
+    };
+  };
+}
+
+export interface MerchantSurpriseDeal {
+  id: number;
+  title: string;
+  surpriseType: SurpriseType;
+  surpriseHint: string;
+  surpriseTotalSlots: number | null;
+  surpriseSlotsUsed: number;
+  isActive: boolean;
+  startTime: string;
+  endTime: string;
+  revealsCount: number;
+  category: { name: string; icon: string };
+  dealType: { name: string };
+}
+
+export interface SurpriseAnalytics {
+  deal: {
+    id: number;
+    title: string;
+    surpriseType: SurpriseType;
+    startTime: string;
+    endTime: string;
+  };
+  analytics: {
+    totalReveals: number;
+    totalRedeemed: number;
+    conversionRate: string;
+    slotsTotal: number | null;
+    slotsUsed: number;
+    slotsRemaining: number | null;
+  };
+  recentReveals: Array<{
+    revealedAt: string;
+    redeemed: boolean;
+    redeemedAt: string | null;
+  }>;
+}
+
+export interface CreateSurpriseDealPayload {
+  title: string;
+  description: string;
+  categoryId: number;
+  dealTypeId: number;
+  startTime: string;
+  endTime: string;
+  redemptionInstructions: string;
+  surpriseType: SurpriseType;
+  surpriseHint?: string;
+  discountPercentage?: number;
+  discountAmount?: number;
+  revealRadiusMeters?: number;
+  revealAt?: string;
+  revealDurationMinutes?: number;
+  surpriseTotalSlots?: number;
+}
+
+export interface AISurpriseSuggestion {
+  title: string;
+  description: string;
+  discountPercentage: number | null;
+  discountAmount: number | null;
+  redemptionInstructions: string;
+  surpriseHint: string;
+  suggestedDurationHours: number;
+  suggestedRevealType: SurpriseType;
+  suggestedRevealRadiusMeters: number | null;
+  bestTimeSlot: string;
+}


### PR DESCRIPTION
- Implement MerchantMySurprisesPage for merchants to view and manage their surprise deals.
- Create SurpriseAnalyticsPage to display analytics for individual surprise deals.
- Add SurpriseCreatePage for merchants to create new surprise deals with AI assistance.
- Define new types in surprises.ts for better type safety and clarity in surprise deal management.